### PR TITLE
Update resource pack to work with the 1.20.5 fog_distance()

### DIFF
--- a/assets/minecraft/shaders/core/render/armor.vsh
+++ b/assets/minecraft/shaders/core/render/armor.vsh
@@ -29,7 +29,7 @@ out vec4 normal;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     texCoord0 = UV0;

--- a/assets/minecraft/shaders/core/render/armor.vsh
+++ b/assets/minecraft/shaders/core/render/armor.vsh
@@ -29,7 +29,7 @@ out vec4 normal;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     texCoord0 = UV0;

--- a/assets/minecraft/shaders/core/render/clouds.vsh
+++ b/assets/minecraft/shaders/core/render/clouds.vsh
@@ -20,7 +20,7 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     texCoord0 = UV0;
-    vertexDistance = fog_distance(ModelViewMat, Position, FogShape);
+    vertexDistance = fog_distance( Position, FogShape);
     vertexColor = Color;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
 }

--- a/assets/minecraft/shaders/core/render/clouds.vsh
+++ b/assets/minecraft/shaders/core/render/clouds.vsh
@@ -20,7 +20,7 @@ void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
     texCoord0 = UV0;
-    vertexDistance = fog_distance( Position, FogShape);
+    vertexDistance = fog_distance(Position, FogShape);
     vertexColor = Color;
     normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
 }

--- a/assets/minecraft/shaders/core/render/end_crystal_beam.vsh
+++ b/assets/minecraft/shaders/core/render/end_crystal_beam.vsh
@@ -30,7 +30,7 @@ out vec4 overlayColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     overlayColor = texelFetch(Sampler1, UV1, 0);

--- a/assets/minecraft/shaders/core/render/end_crystal_beam.vsh
+++ b/assets/minecraft/shaders/core/render/end_crystal_beam.vsh
@@ -30,7 +30,7 @@ out vec4 overlayColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     overlayColor = texelFetch(Sampler1, UV1, 0);

--- a/assets/minecraft/shaders/core/render/energy_swirl.vsh
+++ b/assets/minecraft/shaders/core/render/energy_swirl.vsh
@@ -18,7 +18,7 @@ out vec2 texCoord0;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( Position, FogShape);
+    vertexDistance = fog_distance(Position, FogShape);
     vertexColor = Color;
     texCoord0 = (TextureMat * vec4(UV0, 0.0, 1.0)).xy;
 }

--- a/assets/minecraft/shaders/core/render/energy_swirl.vsh
+++ b/assets/minecraft/shaders/core/render/energy_swirl.vsh
@@ -18,7 +18,7 @@ out vec2 texCoord0;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, Position, FogShape);
+    vertexDistance = fog_distance( Position, FogShape);
     vertexColor = Color;
     texCoord0 = (TextureMat * vec4(UV0, 0.0, 1.0)).xy;
 }

--- a/assets/minecraft/shaders/core/render/eyes.vsh
+++ b/assets/minecraft/shaders/core/render/eyes.vsh
@@ -18,7 +18,7 @@ out vec2 texCoord0;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     vertexColor = Color;
     texCoord0 = UV0;
 }

--- a/assets/minecraft/shaders/core/render/eyes.vsh
+++ b/assets/minecraft/shaders/core/render/eyes.vsh
@@ -18,7 +18,7 @@ out vec2 texCoord0;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     vertexColor = Color;
     texCoord0 = UV0;
 }

--- a/assets/minecraft/shaders/core/render/glint_armor.vsh
+++ b/assets/minecraft/shaders/core/render/glint_armor.vsh
@@ -16,6 +16,6 @@ out vec2 texCoord0;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, Position, FogShape);
+    vertexDistance = fog_distance( Position, FogShape);
     texCoord0 = (TextureMat * vec4(UV0, 0.0, 1.0)).xy;
 }

--- a/assets/minecraft/shaders/core/render/glint_armor.vsh
+++ b/assets/minecraft/shaders/core/render/glint_armor.vsh
@@ -16,6 +16,6 @@ out vec2 texCoord0;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( Position, FogShape);
+    vertexDistance = fog_distance(Position, FogShape);
     texCoord0 = (TextureMat * vec4(UV0, 0.0, 1.0)).xy;
 }

--- a/assets/minecraft/shaders/core/render/glint_item.vsh
+++ b/assets/minecraft/shaders/core/render/glint_item.vsh
@@ -17,6 +17,6 @@ out vec2 texCoord0;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     texCoord0 = (TextureMat * vec4(UV0, 0.0, 1.0)).xy;
 }

--- a/assets/minecraft/shaders/core/render/glint_item.vsh
+++ b/assets/minecraft/shaders/core/render/glint_item.vsh
@@ -17,6 +17,6 @@ out vec2 texCoord0;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     texCoord0 = (TextureMat * vec4(UV0, 0.0, 1.0)).xy;
 }

--- a/assets/minecraft/shaders/core/render/leash.vsh
+++ b/assets/minecraft/shaders/core/render/leash.vsh
@@ -22,6 +22,6 @@ out vec4 lightColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     vertexColor = Color * ColorModulator * minecraft_sample_lightmap(Sampler2, UV2);
 }

--- a/assets/minecraft/shaders/core/render/leash.vsh
+++ b/assets/minecraft/shaders/core/render/leash.vsh
@@ -22,6 +22,6 @@ out vec4 lightColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     vertexColor = Color * ColorModulator * minecraft_sample_lightmap(Sampler2, UV2);
 }

--- a/assets/minecraft/shaders/core/render/lightning.vsh
+++ b/assets/minecraft/shaders/core/render/lightning.vsh
@@ -16,6 +16,6 @@ out vec4 vertexColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     vertexColor = Color;
 }

--- a/assets/minecraft/shaders/core/render/lightning.vsh
+++ b/assets/minecraft/shaders/core/render/lightning.vsh
@@ -16,6 +16,6 @@ out vec4 vertexColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     vertexColor = Color;
 }

--- a/assets/minecraft/shaders/core/render/lines.vsh
+++ b/assets/minecraft/shaders/core/render/lines.vsh
@@ -43,6 +43,6 @@ void main() {
         gl_Position = vec4((ndc1 - vec3(lineOffset, 0.0)) * linePosStart.w, linePosStart.w);
     }
 
-    vertexDistance = fog_distance( Position, FogShape);
+    vertexDistance = fog_distance(Position, FogShape);
     vertexColor = Color;
 }

--- a/assets/minecraft/shaders/core/render/lines.vsh
+++ b/assets/minecraft/shaders/core/render/lines.vsh
@@ -43,6 +43,6 @@ void main() {
         gl_Position = vec4((ndc1 - vec3(lineOffset, 0.0)) * linePosStart.w, linePosStart.w);
     }
 
-    vertexDistance = fog_distance(ModelViewMat, Position, FogShape);
+    vertexDistance = fog_distance( Position, FogShape);
     vertexColor = Color;
 }

--- a/assets/minecraft/shaders/core/render/particle.vsh
+++ b/assets/minecraft/shaders/core/render/particle.vsh
@@ -21,7 +21,7 @@ out vec2 texCoord0;
 
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
-    vertexDistance = fog_distance( Position, FogShape);
+    vertexDistance = fog_distance(Position, FogShape);
     texCoord0 = UV0;
     vertexColor = Color;
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);

--- a/assets/minecraft/shaders/core/render/particle.vsh
+++ b/assets/minecraft/shaders/core/render/particle.vsh
@@ -21,7 +21,7 @@ out vec2 texCoord0;
 
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, Position, FogShape);
+    vertexDistance = fog_distance( Position, FogShape);
     texCoord0 = UV0;
     vertexColor = Color;
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);

--- a/assets/minecraft/shaders/core/render/shadow.vsh
+++ b/assets/minecraft/shaders/core/render/shadow.vsh
@@ -17,7 +17,7 @@ out vec2 texCoord0;
 
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     vertexColor = Color;
     texCoord0 = UV0;
 }

--- a/assets/minecraft/shaders/core/render/shadow.vsh
+++ b/assets/minecraft/shaders/core/render/shadow.vsh
@@ -17,7 +17,7 @@ out vec2 texCoord0;
 
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     vertexColor = Color;
     texCoord0 = UV0;
 }

--- a/assets/minecraft/shaders/core/render/text.vsh
+++ b/assets/minecraft/shaders/core/render/text.vsh
@@ -22,7 +22,7 @@ out vec2 texCoord0;
 
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     vertexColor = Color;
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     texCoord0 = UV0;

--- a/assets/minecraft/shaders/core/render/text.vsh
+++ b/assets/minecraft/shaders/core/render/text.vsh
@@ -22,7 +22,7 @@ out vec2 texCoord0;
 
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     vertexColor = Color;
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     texCoord0 = UV0;

--- a/assets/minecraft/shaders/include/fog.glsl
+++ b/assets/minecraft/shaders/include/fog.glsl
@@ -17,12 +17,12 @@ float linear_fog_fade(float vertexDistance, float fogStart, float fogEnd) {
     return smoothstep(fogEnd, fogStart, vertexDistance);
 }
 
-float fog_distance(mat4 modelViewMat, vec3 pos, int shape) {
+float fog_distance(vec3 pos, int shape) {
     if (shape == 0) {
-        return length((modelViewMat * vec4(pos, 1.0)).xyz);
+        return length(pos);
     } else {
-        float distXZ = length((modelViewMat * vec4(pos.x, 0.0, pos.z, 1.0)).xyz);
-        float distY = length((modelViewMat * vec4(0.0, pos.y, 0.0, 1.0)).xyz);
+        float distXZ = length(pos.xz);
+        float distY = abs(pos.y);
         return max(distXZ, distY);
     }
 }

--- a/assets/minecraft/shaders/include/render/block.vsh
+++ b/assets/minecraft/shaders/include/render/block.vsh
@@ -26,7 +26,7 @@ void main() {
     vec3 pos = Position + ChunkOffset;
     gl_Position = ProjMat * ModelViewMat * vec4(pos, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, pos, FogShape);
+    vertexDistance = fog_distance( pos, FogShape);
     vertexColor = Color;
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     texCoord0 = UV0;

--- a/assets/minecraft/shaders/include/render/block.vsh
+++ b/assets/minecraft/shaders/include/render/block.vsh
@@ -26,7 +26,7 @@ void main() {
     vec3 pos = Position + ChunkOffset;
     gl_Position = ProjMat * ModelViewMat * vec4(pos, 1.0);
 
-    vertexDistance = fog_distance( pos, FogShape);
+    vertexDistance = fog_distance(pos, FogShape);
     vertexColor = Color;
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
     texCoord0 = UV0;

--- a/assets/minecraft/shaders/include/render/entity.vsh
+++ b/assets/minecraft/shaders/include/render/entity.vsh
@@ -33,7 +33,7 @@ out vec4 overlayColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
 #ifdef OVERLAY

--- a/assets/minecraft/shaders/include/render/entity.vsh
+++ b/assets/minecraft/shaders/include/render/entity.vsh
@@ -33,7 +33,7 @@ out vec4 overlayColor;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = fog_distance( IViewRotMat * Position, FogShape);
+    vertexDistance = fog_distance(IViewRotMat * Position, FogShape);
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightColor = minecraft_sample_lightmap(Sampler2, UV2);
 #ifdef OVERLAY


### PR DESCRIPTION
The changes to fog.glsl in [24w05a](https://misode.github.io/versions/?id=24w05a&tab=diff&file=assets/minecraft/shaders/include/fog.glsl) make it so that files not overridden in this resource pack (for example. position.vsh) call the function with the wrong arguments.

This simple change brings over the new fog function and replaces all the calls with the correct parameters.